### PR TITLE
chore(sites-components): export css bundle

### DIFF
--- a/packages/sites-components/package.json
+++ b/packages/sites-components/package.json
@@ -19,7 +19,8 @@
     ".": {
       "import": "./dist/sites-components.js",
       "require": "./dist/sites-components.umd.js"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "engines": {
     "node": "^17 || ^18 || ^19"

--- a/packages/sites-components/src/components/index.ts
+++ b/packages/sites-components/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./address/index.js";
 export * from "./analytics/index.js";
+export * from "./hours/index.js";
 export * from "./image/index.js";
 export * from "./link/index.js";
 export * from "./map/index.js";


### PR DESCRIPTION
Vite bundles CSS for us and outputs the bundle at `dist/style.css`. Since we are providing default styles, we need to export the bundled CSS so it can be used.

We were also not exporting the hours component, so I added it to the `index.ts`.

J=SLAP-2996