### PR TITLE
fix: prevent TS error for link cta prop

### DIFF
--- a/packages/pages-components/src/components/link/link.tsx
+++ b/packages/pages-components/src/components/link/link.tsx
@@ -23,7 +23,7 @@ import type { CTA, LinkProps } from "./types.js";
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function Link(props, ref) {
-    const link: CTA = isHREFProps(props) ? { link: props.href } : props.cta;
+    const link: CTA = props.cta ?? { link: props.href };
     const {
       children,
       onClick,

--- a/packages/pages-components/src/components/link/link.tsx
+++ b/packages/pages-components/src/components/link/link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classNames from "classnames";
 import { useAnalytics } from "../analytics/index.js";
-import { getHref, isEmail, isHREFProps } from "./methods.js";
+import { getHref, getLinkFromProps, isEmail } from "./methods.js";
 import type { CTA, LinkProps } from "./types.js";
 
 /**
@@ -23,7 +23,7 @@ import type { CTA, LinkProps } from "./types.js";
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function Link(props, ref) {
-    const link: CTA = props.cta ?? { link: props.href };
+    const link: CTA = getLinkFromProps(props);
     const {
       children,
       onClick,

--- a/packages/pages-components/src/components/link/methods.ts
+++ b/packages/pages-components/src/components/link/methods.ts
@@ -1,4 +1,4 @@
-import { LinkProps, HREFLinkProps, CTA } from "./types.js";
+import { LinkProps, CTA } from "./types.js";
 
 /**
  * Get the link from a CTA
@@ -54,10 +54,10 @@ const reverse = (string: string): string => {
 };
 
 /**
- * Type predicate for distinguishing between data cases.
+ * Get the CTA from the props if it exists, or return a CTA using the href prop.
  */
-const isHREFProps = (props: LinkProps): props is HREFLinkProps => {
-  return "href" in props;
+const getLinkFromProps = (props: LinkProps): CTA => {
+  return props.cta ?? { link: props.href };
 };
 
-export { getHref, isEmail, isHREFProps, reverse };
+export { getHref, isEmail, getLinkFromProps, reverse };


### PR DESCRIPTION
`isHREFProps` checks if the props include `href` rather than `cta`. We only assign the `cta` prop to the `link` const if this returns false. However, TypeScript would sometimes get confused and assume that `cta` could still be undefined even after this check returned false, which would cause a build error. This replaces the `isHREFProps` method with a new `getLinkFromProps` method which returns the `cta` directly from the props if it exists, or a CTA constructed from the `href` prop otherwise. This improves readability but should produce the same behavior as before, since the types declare that either the `cta` or `href` exists on the props, but not both.