### PR TITLE
fix(pages-components): faq type check

### DIFF
--- a/packages/pages-components/src/components/schema/schemaTypes/FAQPage.tsx
+++ b/packages/pages-components/src/components/schema/schemaTypes/FAQPage.tsx
@@ -50,14 +50,19 @@ const FAQPage = (data: FAQ[]) => {
   return {
     "@context": "http://www.schema.org",
     "@type": "FAQPage",
-    mainEntity: data.map((faq) => ({
-      "@type": "Question",
-      name: faq.question,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "answer" in faq ? faq.answer : getRichTextContent(faq.answerV2),
-      },
-    })),
+    mainEntity: data.map((faq) => {
+      if (typeof faq !== "object") {
+        return undefined;
+      }
+      return {
+        "@type": "Question",
+        name: faq.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "answer" in faq ? faq.answer : getRichTextContent(faq.answerV2),
+        },
+      };
+    }),
   };
 };
 


### PR DESCRIPTION
As far as I can tell, this is the only place where a bad input type would cause an error as opposed to just returning undefined/empty data.

@mkilpatrick Do we want to throw errors or print warnings in other places?

For example:
```
const Product = (document: Record<string, any>, schemaType?: string) => {
  return {
    ...BaseSchema(document, schemaType ?? "Product"),
    ...PhotoGallerySchema(document.photoGallery),
    ...ReviewSchema(document.c_reviews),
    ...AggregateRatingSchema(document.c_aggregateRating),
    ...OfferSchema({
      url: "",
      priceCurrency: document.c_currency,
      price: document.price,
      priceValidUntil: document.expirationDate,
      itemCondition: document.stockStatus,
      availability: document.availabilityDate,
    }),
    description: document.description,
    sku: document.sku,
    mpn: document.mpn,
    brand: {
      "@type": "Brand",
      name: document.brand,
    },
  };
};

export const AggregateRatingSchema = (rating?: AggregateRating) => {
  return (
    rating && {
      aggregateRating: {
        "@type": "AggregateRating",
        ratingValue: rating.ratingValue,
        reviewCount: rating.reviewCount,
      },
    }
  );
};

```

If there is no `c_aggregateRating` field on the document, `aggregateRating` won't appear in the returned schema.

If `c_aggregateRating` is on the document but is a Number instead of an Object,  Product will return undefined values
```
...
  aggregateRating: {
    '@type': 'AggregateRating',
    ratingValue: undefined,
    reviewCount: undefined
  },
```