### PR TITLE
fix(pages-components): unique key for address line separators

### DIFF
--- a/packages/pages-components/src/components/address/address.test.tsx
+++ b/packages/pages-components/src/components/address/address.test.tsx
@@ -45,4 +45,23 @@ describe("Address", () => {
 
     expect(cityEl && regionEl).toBeFalsy();
   });
+
+  it("renders custom lines with separators without warnings", () => {
+    const originalError = console.error;
+    console.error = vi.fn();
+
+    render(
+      <Address
+        address={address}
+        lines={[
+          ["line1", ",", "line2"],
+          ["city", ",", "region", ",", "postalCode"],
+        ]}
+      />
+    );
+
+    expect(console.error).not.toHaveBeenCalled();
+
+    console.error = originalError;
+  });
 });

--- a/packages/pages-components/src/components/address/address.tsx
+++ b/packages/pages-components/src/components/address/address.tsx
@@ -50,10 +50,13 @@ const AddressLine = ({
   separator,
 }: AddressLineProps): JSX.Element => {
   const addressDOM: JSX.Element[] = [];
+  let separatorCount = 0;
 
   for (const field of line) {
     if (field === ",") {
-      addressDOM.push(<span key={field}>{separator}</span>);
+      addressDOM.push(
+        <span key={`separator-${separatorCount++}`}>{separator}</span>
+      );
       continue;
     }
 


### PR DESCRIPTION
When multiple separators were used on the same line, the keys (`,`) were not unique. Eg. the following example resulted in warnings:

```
<Address
  address={address}
  lines={[
    ["line1", "line2"],
    ["city", ",", "region", ",", "postalCode"],
  ]}
/>;
```