### PR TITLE
fix: add page url to events payload

### DIFF
--- a/packages/pages-components/src/components/analytics/Analytics.ts
+++ b/packages/pages-components/src/components/analytics/Analytics.ts
@@ -94,6 +94,7 @@ export class Analytics implements AnalyticsMethods {
         template: this.templateData.document.__.name,
       },
       entity: (this.templateData.document.uid as number) || undefined,
+      pageUrl: document.URL,
       referrerUrl: document.referrer !== "" ? document.referrer : undefined,
     };
 


### PR DESCRIPTION
While analytics will set pageUrl automatically, it only sends the origin and not the individual page url because of the `strict-origin-when-cross-origin` header.

Confirmed that the url with path and query parameters appeared in snowflake