### PR TITLE
refactor(pages-components): make destinationUrl optional for analytics.track

### DIFF
--- a/packages/pages-components/src/components/analytics/interfaces.ts
+++ b/packages/pages-components/src/components/analytics/interfaces.ts
@@ -3,7 +3,7 @@ import { TemplateProps } from "./types.js";
 
 export type TrackProps = {
   action: Action;
-  destinationUrl: string;
+  destinationUrl?: string;
   scope?: string;
   eventName: string;
   amount?: number;


### PR DESCRIPTION
`destinationUrl` isn't required by the underlying `_analyticsEventService.report` and doesn't make sense for non-link analytics. It is validated during analytics ingesting so it cannot be set to `""` or `"#"`