### PR TITLE
fix(pages-components): make a mutable copy of cta in resolveCTA

### DIFF
--- a/packages/pages-components/CHANGELOG.md
+++ b/packages/pages-components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##### Bug Fixes
 
-* **pages-components:**  rel not propagating in Link (#101) (1506993c)
+- **pages-components:** rel not propagating in Link (#101) (1506993c)
 
 #### 1.1.9 (2025-07-02)
 

--- a/packages/pages-components/src/components/link/methods.test.ts
+++ b/packages/pages-components/src/components/link/methods.test.ts
@@ -181,3 +181,14 @@ test("resolveCTA - error when cta and no link", () => {
   } as LinkProps;
   expect(() => resolveCTA(linkProps)).toThrowError("CTA's link is undefined");
 });
+
+test("resolveCTA - handles immutable object", () => {
+  const linkProps = {
+    cta: Object.freeze({
+      label: "",
+      link: "google.com",
+      linkType: "URL",
+    }),
+  } as LinkProps;
+  expect(() => resolveCTA(linkProps)).not.toThrowError();
+});

--- a/packages/pages-components/src/components/link/methods.ts
+++ b/packages/pages-components/src/components/link/methods.ts
@@ -14,7 +14,8 @@ export const LEGACY_CTA_EVENT = "cta";
  * are optional.
  */
 export const resolveCTA = (linkProps: LinkProps): CTA => {
-  const cta = linkProps.cta ?? { link: linkProps.href };
+  // Create a mutable copy of the cta object
+  const cta = { ...(linkProps.cta ?? { link: linkProps.href }) };
 
   if (!cta.link) {
     if (linkProps.cta) {


### PR DESCRIPTION
`const cta = linkProps.cta ?? { link: linkProps.href };` was immutable when using `linkProps.cta` in the case when linkProps was passed in immutably. This can happen when mapping:

```
{results.map((result) => (
        <ResultListItem
          key={result.id || result.index}
          result={result}  <-- result is immutable
          isMapView={props.isMapView}
          brand={props.brand}
        />
      ))}
```