### PR TITLE
fix(pages-components): strip empty destinationUrl

### DIFF
--- a/packages/pages-components/src/components/analytics/Analytics.ts
+++ b/packages/pages-components/src/components/analytics/Analytics.ts
@@ -175,7 +175,7 @@ export class Analytics implements AnalyticsMethods {
         originalEventName: concatScopes(scope || "", slugify(eventName) || ""),
       },
       value,
-      destinationUrl,
+      destinationUrl: destinationUrl || undefined,
       customTags,
       customValues,
     });

--- a/packages/pages-components/src/components/analytics/analytics.test.tsx
+++ b/packages/pages-components/src/components/analytics/analytics.test.tsx
@@ -15,6 +15,7 @@ import { Link } from "../link/index.js";
 import { AnalyticsProvider } from "./provider.js";
 import { AnalyticsScopeProvider } from "./scope.js";
 import { Action } from "@yext/analytics";
+import { useAnalytics } from "./hooks.js";
 
 vi.mock("../../util/runtime.js", () => {
   const runtime = {
@@ -276,5 +277,40 @@ describe("Analytics", () => {
         />
       )
     ).toThrowError("API Key is required for AnalyticsProvider");
+  });
+
+  it("strips empty string destinationUrl", () => {
+    const Button = () => {
+      const analytics = useAnalytics();
+      return (
+        <button
+          onClick={() => {
+            analytics?.track({
+              action: "CTA_CLICK",
+              destinationUrl: "",
+              eventName: "header_button",
+            });
+          }}
+        />
+      );
+    };
+
+    render(
+      <AnalyticsProvider
+        apiKey="key"
+        currency="USD"
+        templateData={baseProps}
+        requireOptIn={false}
+      >
+        <Button />
+      </AnalyticsProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    // @ts-ignore
+    const callstack = global.fetch.mock.calls;
+    const payload = JSON.parse(callstack[callstack.length - 1][1].body);
+
+    expect(payload.destinationUrl).toBeUndefined();
   });
 });


### PR DESCRIPTION
An empty string `destinationUrl` sent to the Events API results in the error:
```
$.destinationUrl: does not match the uri pattern ^[A-Za-z][A-Za-z0-9+.-]*:(\/\/([A-Za-z0-9._~\-%!$&'()*+,;=:]*@)?[A-Za-z0-9._~\-!$&'()*+,;=%:\[\]]*(:[0-9]*)?)?[A-Za-z0-9._~\-%!$&'()*+,;=:@\/]*([?][A-Za-z0-9._~\-%!$&'()*+,;=:@\/?]*)?([#][A-Za-z0-9._~\-%!$&'()*+,;=:@\/?]*)?
```

If `track` sees an empty string it will now not pass it at all.