### PR TITLE
fix: provide correct tag for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,8 @@ jobs:
         id: get_npm_tag
         run: pnpm run ci-verify-publish ${{ github.ref_name }}
 
-      - name: Switch to the main branch
-        run: git checkout main
+      - name: Allow publishing from detached HEAD
+        run: pnpm config set publish-branch ""
 
       - name: Publish
-        run: cd packages/pages-components && pnpm publish --access public --tag ${{ github.ref_name }}
+        run: cd packages/pages-components && pnpm publish --access public --tag ${{ steps.get_npm_tag.outputs.npm_tag }}

--- a/scripts/verifyPublish.ts
+++ b/scripts/verifyPublish.ts
@@ -23,7 +23,7 @@ const releaseTag = version.includes("rc")
     ? "beta"
     : version.includes("alpha")
       ? "alpha"
-      : undefined;
+      : "latest";
 
 // Log the release tag to be picked up by the next GitHub Actions step
 console.log(releaseTag);


### PR DESCRIPTION
We want verifyPublish to return `latest` when no other tag is specified. We also want to publish using the static tag itself rather than just the main branch, which could change.