### PR TITLE
chore: prevent shell injection in github action (vuln-44056)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,11 +39,15 @@ jobs:
 
       - name: Verify package version and get npm tag
         id: get_npm_tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          TAG=$(pnpm run ci-verify-publish ${{ github.ref_name }} | tail -n 1)
-          echo "npm_tag=$TAG" >> $GITHUB_OUTPUT
+          TAG=$(pnpm run ci-verify-publish "$REF_NAME" | tail -n 1)
+          echo "npm_tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Publish
+        env:
+          NPM_TAG: ${{ steps.get_npm_tag.outputs.npm_tag }}
         run: |
           cd packages/pages-components
-          pnpm publish --access public --tag ${{ steps.get_npm_tag.outputs.npm_tag }} --no-git-checks
+          pnpm publish --access public --tag "$NPM_TAG" --no-git-checks

--- a/packages/pages-components/CHANGELOG.md
+++ b/packages/pages-components/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ##### Bug Fixes
 
-*  render hours using useIsomorphicLayoutEffect ([#147](https://github.com/yext/js/pull/147)) ([bdf6dcf0](https://github.com/yext/js/commit/bdf6dcf0a824f02f9c16e752998d5879622ba0c0))
-*  force secure version of axios ([#146](https://github.com/yext/js/pull/146)) ([66b06574](https://github.com/yext/js/commit/66b06574d468d13a1d7e71aa2e24b64276b42d3b))
+- render hours using useIsomorphicLayoutEffect ([#147](https://github.com/yext/js/pull/147)) ([bdf6dcf0](https://github.com/yext/js/commit/bdf6dcf0a824f02f9c16e752998d5879622ba0c0))
+- force secure version of axios ([#146](https://github.com/yext/js/pull/146)) ([66b06574](https://github.com/yext/js/commit/66b06574d468d13a1d7e71aa2e24b64276b42d3b))
 
 #### 2.1.0 (2026-03-19)
 


### PR DESCRIPTION
> Summary
Using variable interpolation `$...` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".