### PR TITLE
fix: force secure version of axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "packageManager": "pnpm@9.12.3",
   "pnpm": {
     "overrides": {
-      "axios": "1.15.0"
+      "axios": "1.16.0"
     }
   }
 }

--- a/packages/pages-components/CHANGELOG.md
+++ b/packages/pages-components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##### New Features
 
-*  add "Coming Soon" to HoursStatus and HoursTable ([#150](https://github.com/yext/js/pull/150)) ([fade807e](https://github.com/yext/js/commit/fade807eea7ddbc96c91883bd11784de8463366a))
+- add "Coming Soon" to HoursStatus and HoursTable ([#150](https://github.com/yext/js/pull/150)) ([fade807e](https://github.com/yext/js/commit/fade807eea7ddbc96c91883bd11784de8463366a))
 
 #### 2.1.2 (2026-05-06)
 

--- a/packages/pages-components/package.json
+++ b/packages/pages-components/package.json
@@ -50,7 +50,7 @@
     "luxon": "^3.7.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^8.6.17",
     "@storybook/addon-essentials": "^8.6.17",
     "@storybook/addon-interactions": "^8.6.17",
@@ -79,7 +79,7 @@
     "jsdom": "^24.1.0",
     "lightningcss-cli": "^1.30.2",
     "picocolors": "^1.1.1",
-    "playwright-core": "^1.55.1",
+    "playwright-core": "^1.60.0",
     "postcss": "^8.5.6",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: 1.15.0
+  axios: 1.16.0
 
 importers:
 
@@ -231,7 +231,7 @@ importers:
         version: 4.3.4(vite@5.4.21(@types/node@20.17.19))
       '@yext/pages':
         specifier: ^1.2.7
-        version: 1.2.7(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.15.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3)(vite@5.4.21(@types/node@20.17.19))
+        version: 1.2.7(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.16.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3)(vite@5.4.21(@types/node@20.17.19))
       typescript:
         specifier: ^5.3.3
         version: 5.7.3
@@ -2127,7 +2127,7 @@ packages:
     resolution: {integrity: sha512-5fzRl0apQWrDezmobchoiGTkGw238VWESxZHazfhP3RM7pDSiyXy18QbfYkILoYNTd23HPAfQTJpkUc5QbkwTw==}
     peerDependencies:
       async-validator: ^4
-      axios: 1.15.0
+      axios: 1.16.0
       change-case: ^5
       drauu: ^0.4
       focus-trap: ^7
@@ -2345,8 +2345,8 @@ packages:
     peerDependencies:
       playwright: '>1.0.0'
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -8154,13 +8154,13 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@11.3.0(axios@1.15.0)(focus-trap@7.6.6)(vue@3.5.25(typescript@5.7.3))':
+  '@vueuse/integrations@11.3.0(axios@1.16.0)(focus-trap@7.6.6)(vue@3.5.25(typescript@5.7.3))':
     dependencies:
       '@vueuse/core': 11.3.0(vue@3.5.25(typescript@5.7.3))
       '@vueuse/shared': 11.3.0(vue@3.5.25(typescript@5.7.3))
       vue-demi: 0.14.10(vue@3.5.25(typescript@5.7.3))
     optionalDependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       focus-trap: 7.6.6
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -8179,7 +8179,7 @@ snapshots:
     dependencies:
       ulidx: 2.4.1
 
-  '@yext/pages@1.2.7(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.15.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3)(vite@5.4.21(@types/node@20.17.19))':
+  '@yext/pages@1.2.7(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.16.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3)(vite@5.4.21(@types/node@20.17.19))':
     dependencies:
       ansi-to-html: 0.7.2
       browser-or-node: 2.1.1
@@ -8205,7 +8205,7 @@ snapshots:
       ts-morph: 22.0.0
       vite: 5.4.21(@types/node@20.17.19)
       vite-plugin-node-polyfills: 0.17.0(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.19))
-      vitepress: 1.5.0(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.15.0)(postcss@8.5.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3)
+      vitepress: 1.5.0(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.16.0)(postcss@8.5.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3)
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -8395,7 +8395,7 @@ snapshots:
       picocolors: 1.1.1
       playwright: 1.57.0
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -12552,7 +12552,7 @@ snapshots:
       '@types/node': 20.17.19
       fsevents: 2.3.3
 
-  vitepress@1.5.0(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.15.0)(postcss@8.5.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3):
+  vitepress@1.5.0(@algolia/client-search@5.46.0)(@types/node@20.17.19)(@types/react@18.3.27)(axios@1.16.0)(postcss@8.5.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.7.3):
     dependencies:
       '@docsearch/css': 3.9.0
       '@docsearch/js': 3.9.0(@algolia/client-search@5.46.0)(@types/react@18.3.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
@@ -12565,7 +12565,7 @@ snapshots:
       '@vue/devtools-api': 7.7.9
       '@vue/shared': 3.5.25
       '@vueuse/core': 11.3.0(vue@3.5.25(typescript@5.7.3))
-      '@vueuse/integrations': 11.3.0(axios@1.15.0)(focus-trap@7.6.6)(vue@3.5.25(typescript@5.7.3))
+      '@vueuse/integrations': 11.3.0(axios@1.16.0)(focus-trap@7.6.6)(vue@3.5.25(typescript@5.7.3))
       focus-trap: 7.6.6
       mark.js: 8.11.1
       minisearch: 7.2.0
@@ -12661,7 +12661,7 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         version: 3.20.0
     devDependencies:
       '@playwright/test':
-        specifier: ^1.55.1
-        version: 1.56.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@storybook/addon-a11y':
         specifier: ^8.6.17
         version: 8.6.18(storybook@8.6.18(prettier@3.5.1))
@@ -152,7 +152,7 @@ importers:
         version: 4.10.2
       axe-playwright:
         specifier: ^1.2.3
-        version: 1.2.3(playwright@1.57.0)
+        version: 1.2.3(playwright@1.60.0)
       generate-license-file:
         specifier: ^3.0.1
         version: 3.7.0(typescript@5.7.3)
@@ -169,8 +169,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       playwright-core:
-        specifier: ^1.55.1
-        version: 1.56.1
+        specifier: ^1.60.0
+        version: 1.60.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -215,8 +215,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.57.0
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^20.9.1
         version: 20.17.19
@@ -1329,13 +1329,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@playwright/test@1.57.0':
-    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4809,8 +4804,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4819,8 +4814,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.57.0:
-    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7230,13 +7225,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.56.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.56.1
-
-  '@playwright/test@1.57.0':
-    dependencies:
-      playwright: 1.57.0
+      playwright: 1.60.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -8388,12 +8379,12 @@ snapshots:
       mustache: 4.2.0
       rimraf: 3.0.2
 
-  axe-playwright@1.2.3(playwright@1.57.0):
+  axe-playwright@1.2.3(playwright@1.60.0):
     dependencies:
       axe-core: 4.10.2
       axe-html-reporter: 2.2.3(axe-core@4.10.2)
       picocolors: 1.1.1
-      playwright: 1.57.0
+      playwright: 1.60.0
 
   axios@1.16.0:
     dependencies:
@@ -10234,7 +10225,7 @@ snapshots:
       jest-process-manager: 0.4.0
       jest-runner: 29.7.0
       nyc: 15.1.0
-      playwright-core: 1.56.1
+      playwright-core: 1.60.0
       rimraf: 3.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -11382,7 +11373,7 @@ snapshots:
 
   playwright-core@1.56.1: {}
 
-  playwright-core@1.57.0: {}
+  playwright-core@1.60.0: {}
 
   playwright@1.56.1:
     dependencies:
@@ -11390,9 +11381,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  playwright@1.57.0:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.57.0
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/test-sites/pages-components-starter/package.json
+++ b/test-sites/pages-components-starter/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^20.9.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",


### PR DESCRIPTION
This ensures that axios version 1.16.0 is used, which avoids the following vulnerability present in 1.15.0.

https://github.com/advisories/GHSA-pjwm-pj3p-43mv

Also upgraded playwright as I was seeing Github actions hang on the browser install step, which has been fixed in 1.60.0.

https://github.com/microsoft/playwright/issues/40998